### PR TITLE
Adds new frequent-keep3r example that queries every 5s

### DIFF
--- a/keep3rs/README.md
+++ b/keep3rs/README.md
@@ -10,6 +10,8 @@ This folder has Autotask scripts for running [Keep3rs](https://docs.keep3r.netwo
 
 - [`multiple-jobs-keeper`](src/multiple-jobs-keeper.js) requires a Relayer already activated as a Keeper as well, but will attempt to work from the [`HegicPoolKeep3r`](https://etherscan.io/address/0x5DDe926b0A31346f2485900C5e64c2577F43F774), [`UniswapV2SlidingOracle`](https://etherscan.io/address/0xCA2E2df6A7a7Cf5bd19D112E8568910a6C2D3885), and [`YearnV1EarnKeep3r`](https://etherscan.io/address/0xe7F4ab593aeC81EcA754Da1B3B7cE0C42a13Ec0C) jobs.
 
+- [`frequent-keeper`](src/frequent-keeper.js) will execute the same jobs as `multiple-jobs-keeper`, prior to validating that the current Relayer is a Keeper, but will query for available jobs every 5 seconds, and terminate after 1 minute. You can schedule this autotask to run every minute in order to be checking for available jobs on every new block.
+
 - [`autoregister-keeper`](src/autoregister-keeper.js) will automatically bond the attached Relayer as a Keeper with zero collateral, wait for the activation period to finish, activate the relayer, and then execute the same jobs as `multiple-jobs-keeper`.
 
 ## Setup

--- a/keep3rs/src/frequent-keeper.js
+++ b/keep3rs/src/frequent-keeper.js
@@ -1,0 +1,94 @@
+const { ethers } = require("ethers");
+const { DefenderRelaySigner } = require('defender-relay-client/lib/ethers');
+
+// ABIs for jobs and registry (contain only the methods needed, not the full ABIs of the contracts)
+const ABIs = {
+  UniswapV2SlidingOracle: [{"inputs":[],"name":"workable","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"work","outputs":[],"stateMutability":"nonpayable","type":"function"}],
+  HegicPoolKeep3r: [{"inputs":[],"name":"workable","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"claimRewards","outputs":[],"stateMutability":"nonpayable","type":"function"}],
+  YearnV1EarnKeep3r: [{"inputs":[],"name":"work","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"workable","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}],
+  Registry: [{"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"keepers","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"bonding","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"bond","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"}],"name":"bondings","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"bonding","type":"address"}],"name":"activate","outputs":[],"stateMutability":"nonpayable","type":"function"}],
+}
+
+// Definition for all jobs to execute
+const Jobs = [
+  { name: 'UniswapV2SlidingOracle', address: '0xCA2E2df6A7a7Cf5bd19D112E8568910a6C2D3885', workableFn: 'workable', workFn: 'work' },
+  { name: 'HegicPoolKeep3r',        address: '0x5DDe926b0A31346f2485900C5e64c2577F43F774', workableFn: 'workable', workFn: 'claimRewards' },
+  { name: 'YearnV1EarnKeep3r',      address: '0xe7F4ab593aeC81EcA754Da1B3B7cE0C42a13Ec0C', workableFn: 'workable', workFn: 'work' },
+];
+
+// Address for the Keeper registry
+const RegistryAddress = '0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44';
+
+// Running time of this autotask
+const Duration = 55000;
+
+// Pauses for milliseconds
+async function sleep(ms) {
+  return new Promise(resolve => {
+    setTimeout(() => resolve(), ms);
+  });
+}
+
+// Checks if there is available work on the job and works it
+async function workIfNeeded(contract, job) {
+  if (await contract[job.workableFn]()) {
+    console.log(`${job.name} is workable`);
+    const tx = await contract[job.workFn]();
+    console.log(`${job.name} worked: ${tx.hash}`);
+    return true;
+  } 
+  return false;
+}
+
+// Checks if there is available work on the job every 5s
+// There is no need to check more often, since checking once per block is enough
+// Avoid further increasing the frequency or it may lead to provider quota errors
+async function tryWorking(signer, job, duration) {
+  try {
+    const start = Date.now();
+    const contract = new ethers.Contract(job.address, ABIs[job.name], signer);
+    while (Date.now() - start < duration) {
+      if (await workIfNeeded(contract, job)) return;
+      await sleep(duration / 11);
+    }
+    console.log(`${job.name} is not workable`);
+  } catch (err) {
+    console.log(`Error working ${job.name}: ${err.message ? err.message.slice(0, 100) : 'unknown error'}`);
+  }
+}
+
+async function main(signer, jobs, duration, registryAddress) {
+  // Check if relayer is a registered keeper
+  const registry = new ethers.Contract(registryAddress, ABIs.Registry, signer);
+  const keeperAddress = await signer.getAddress();
+  const isKeeper = await registry.keepers(keeperAddress);
+  if (!isKeeper) {
+    console.log(`Relayer ${keeperAddress} has not yet been activated as a keep3r`);
+    return;
+  }
+
+  // Monitor all jobs in parallel every 5 seconds and return after 1 min
+  console.log(`Starting work...`);
+  await Promise.all(jobs.map(job => tryWorking(signer, job, duration)));
+}
+
+// Entrypoint for the Autotask
+exports.handler = async function(credentials) {
+  const provider = ethers.getDefaultProvider();
+  const signer = new DefenderRelaySigner(credentials, provider, { speed: 'fastest' });
+  await main(signer, Jobs, Duration, RegistryAddress);
+}
+
+// For unit testing
+exports.main = main;
+exports.Jobs = Jobs;
+
+// To run locally (this code will not be executed in Autotasks)
+if (require.main === module) {
+  require('dotenv').config();
+  const { API_KEY: apiKey, API_SECRET: apiSecret } = process.env;
+  exports.handler({ apiKey, apiSecret })
+    .then(() => process.exit(0))
+    .catch(error => { console.error(error); process.exit(1); });
+}
+

--- a/keep3rs/test/autoregister-keeper.test.js
+++ b/keep3rs/test/autoregister-keeper.test.js
@@ -22,6 +22,10 @@ describe("autoregister-keeper", function() {
     keeperAddress = await keeper.getAddress();
   });
 
+  after(function () {
+    mockdate.reset();
+  });
+
   // Emulates autotask run
   const run = () => main(keeper, jobs, registry.address);
 

--- a/keep3rs/test/frequent-keeper.test.js
+++ b/keep3rs/test/frequent-keeper.test.js
@@ -1,0 +1,65 @@
+const { expect } = require("chai");
+const { main, Jobs } = require("../src/frequent-keeper");
+
+async function deploy(name) {
+  const contract = await ethers.getContractFactory(name)
+    .then(f => f.deploy())
+    .then(c => c.deployed());
+  contract.name = name;
+  return contract;
+}
+
+describe("faster-keeper", function() {
+  const workableNames = ['YearnV1EarnKeep3r', 'HegicPoolKeep3r', 'UniswapV2SlidingOracle'];
+  let workables, jobs, keeper, keeperAddress, registry;
+
+  before(async function () {
+    workables = await Promise.all(workableNames.map(name => deploy(name)));
+    jobs = Jobs.map(job => ({ ...job, address: workables.find(w => w.name === job.name).address }));
+    keeper = await ethers.getSigners().then(signers => signers[2]);
+    keeperAddress = await keeper.getAddress();
+    registry = await deploy('KeeperRegistry').then(c => c.connect(keeper));
+  });
+
+  // Emulates autotask run
+  const run = () => main(keeper, jobs, 1000, registry.address);
+
+  it("skips if keeper is not registered", async function () {
+    await Promise.all(workables.map(workable => workable.requestWork()));
+    const txCount = await keeper.getTransactionCount();
+    await run();
+    expect(await keeper.getTransactionCount()).to.eq(txCount);
+  });
+
+  it("works on all available jobs if registered", async function () {
+    await registry.bond(registry.address, 0);
+    await ethers.provider.send('evm_increaseTime', [650]);
+    await registry.activate(registry.address);
+
+    const txCount = await keeper.getTransactionCount();
+    await Promise.all(workables.map(workable => workable.requestWork()));
+    
+    await run();
+    
+    expect(await keeper.getTransactionCount()).to.eq(txCount + jobs.length);
+    const worksNeeded = await Promise.all(workables.map(workable => workable.needsWork()));
+    expect(worksNeeded).to.be.deep.eq(jobs.map(() => false));
+  });
+
+  it("skips if there is no work to be done for any job", async function () {
+    const txCount = await keeper.getTransactionCount();
+    await run();
+    expect(await keeper.getTransactionCount()).to.eq(txCount);
+  });
+
+  it("discovers work during run", async function () {
+    const txCount = await keeper.getTransactionCount();
+    const [workable] = workables;
+    setTimeout(() => workable.requestWork(), 200);
+
+    await run();
+    
+    expect(await keeper.getTransactionCount()).to.eq(txCount + 1);
+    expect(await workable.needsWork()).to.eq(false);
+  });
+});

--- a/keep3rs/test/multiple-jobs-keeper.test.js
+++ b/keep3rs/test/multiple-jobs-keeper.test.js
@@ -16,7 +16,7 @@ describe("multiple-jobs-keeper", function() {
   before(async function () {
     workables = await Promise.all(workableNames.map(name => deploy(name)));
     jobs = Jobs.map(job => ({ ...job, address: workables.find(w => w.name === job.name).address }));
-    keeper = await ethers.getSigners().then(signers => signers[1]);
+    keeper = await ethers.getSigners().then(signers => signers[3]);
     keeperAddress = await keeper.getAddress();
   });
 

--- a/keep3rs/test/simple-keeper.test.js
+++ b/keep3rs/test/simple-keeper.test.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { main, Jobs } = require("../src/simple-keeper");
+const { main } = require("../src/simple-keeper");
 
 async function deploy(name) {
   const contract = await ethers.getContractFactory(name)
@@ -9,12 +9,12 @@ async function deploy(name) {
   return contract;
 }
 
-describe("multiple-jobs-keeper", function() {
+describe("simple-keeper", function() {
   let workable, keeper, keeperAddress;
 
   before(async function () {
     workable = await deploy('YearnV1EarnKeep3r');
-    keeper = await ethers.getSigners().then(signers => signers[1]);
+    keeper = await ethers.getSigners().then(signers => signers[4]);
     keeperAddress = await keeper.getAddress();
   });
 


### PR DESCRIPTION
Wait until we provide our own query providers before merging, otherwise all users will end up with quota exceeded on the shared infura/alchemy/etherscan api keys.